### PR TITLE
Upgrade commons-collections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-collections4</artifactId>
-			<version>4.0</version>
+			<version>4.1</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,11 @@
 					<artifactId>cobertura-maven-plugin</artifactId>
 					<version>2.6</version>
 				</plugin>
+				<plugin>
+                                        <groupId>org.owasp</groupId>
+                                        <artifactId>dependency-check-maven</artifactId>
+                                        <version>1.4.5</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>


### PR DESCRIPTION
Hello :)

When checking some projects with Dependency-check I discovered that RequestCorrelationSlf4J
 depends on a vulnerable version of commons-collections4:
```
One or more dependencies were identified with known vulnerabilities in RequestCorrelationSlf4J:

commons-collections4-4.0.jar (cpe:/a:apache:commons_collections:4.0, org.apache.commons:commons-collections4:4.0) : CVE-2015-6420
```

See http://commons.apache.org/proper/commons-collections/release_4_1.html or https://issues.apache.org/jira/browse/COLLECTIONS-580 for more details.

`mvn clean package` ran succesfully after upgrading. I got some error messages when it tried to run `cmd` as part of the install phase but that doesn't seem to be affected by the library upgrade. 